### PR TITLE
Feature/admin mail

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -251,9 +251,15 @@ class AdminController extends Controller
 
     // お知らせメール送信処理 =======================================================
     public function sendAdminMail(Request $request) {
-        $users = User::all();
+        // バリデーション
+        $request->validate([
+            'subject' => ['required'],
+            'main_text' => ['required'],
+        ]);
 
         try {
+            $users = User::all();
+
             // 一斉メール送信
             // foreach($users as $user) {
             //     Mail::to($user->email)

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -241,4 +241,12 @@ class AdminController extends Controller
         );
     }
 
+    // お知らせメール作成ページ表示 =================================================
+    public function createAdminMail(Request $request) {
+        return view('admin.create_admin_mail');
+    }
+
+    // お知らせメール送信処理 =======================================================
+
+
 }

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -12,6 +12,9 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Carbon\Carbon;
 use Carbon\CarbonImmutable;
+use Lang;
+use Mail;
+use App\Mail\AdminMail;
 
 class AdminController extends Controller
 {
@@ -242,11 +245,47 @@ class AdminController extends Controller
     }
 
     // お知らせメール作成ページ表示 =================================================
-    public function createAdminMail(Request $request) {
+    public function createAdminMail() {
         return view('admin.create_admin_mail');
     }
 
     // お知らせメール送信処理 =======================================================
+    public function sendAdminMail(Request $request) {
+        $users = User::all();
 
+        try {
+            // 一斉メール送信
+            // foreach($users as $user) {
+            //     Mail::to($user->email)
+            //         ->send(new AdminMail(
+            //                     $user->name,
+            //                     $request->subject,
+            //                     $request->main_text,
+            //     ));
+            // }
+
+            // googleメールの送信制限は1日「500件」まで
+            // 制限にかからないよう「10件」でテスト
+            for($i=0; $i<10; $i++) {
+                Mail::to($users[$i]->email)
+                    ->send(new AdminMail(
+                        $users[$i]->name,
+                        $request->subject,
+                        $request->main_text,
+                ));
+            }
+            $message = Lang::get('message.SENT_MAIL');
+            $is_sent = true;
+        } catch (\Exception $e) {
+            $message = Lang::get('message.ERR_MAIL');
+            $is_sent = false;
+            Log::error($e);
+        }
+
+        return redirect('/admin/admin_mail')->with([
+            'message' => $message,
+            'is_sent' => $is_sent,
+        ]);
+    }
 
 }

--- a/app/Mail/AdminMail.php
+++ b/app/Mail/AdminMail.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class AdminMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $subject;
+    protected $main_text;
+    protected $name;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct($name, $subject, $main_text)
+    {
+        $this->name = $name;
+        $this->subject = $subject;
+        $this->main_text = $main_text;
+    }
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: $this->subject,
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.admin_mail',
+            with: [
+                'main_text' => $this->main_text,
+                'name' => $this->name,
+            ],
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/lang/ja/message.php
+++ b/lang/ja/message.php
@@ -1,9 +1,16 @@
 <?php
 
 return [
+    // 認証関連メッセージ
     'ERR_USER_NOT_FOUND' => '一致するユーザーが見つかりません',
     'ERR_PASSWORD_MISMATCH' => 'パスワードが一致しません',
     'ERR_TOKEN_EXPIRED' => 'ログイン認証用URLの有効期限が切れています',
     'ERR_LOGIN' => 'ログイン認証エラーが発生しました',
+
+    // メール関連
+    'SENT_MAIL' => 'メール送信しました',
+    'ERR_MAIL' => 'メール送信でエラーが発生しました',
+
+    // その他汎用メッセージ
     'ERR_UNKNOWN' => 'エラーが発生しました',
 ];

--- a/lang/ja/validation.php
+++ b/lang/ja/validation.php
@@ -156,7 +156,9 @@ return [
         'title' => 'タイトル',
         'comment' => 'コメント',
         'detail' => '詳細文',
-        'images' => '画像'
+        'images' => '画像',
+        'subject' => '件名',
+        'main_text' => '本文',
     ],
 
     'values' => [

--- a/public/css/admin/create_admin_mail.css
+++ b/public/css/admin/create_admin_mail.css
@@ -1,0 +1,75 @@
+.register-wrapper {
+    margin: 0 auto;
+    max-width: 800px;
+}
+
+.register-content {
+    border: solid 1px #959997;
+    border-radius: 8px;
+    box-shadow: 2px 2px 3px #aaa;
+}
+
+.register-content__heading {
+    padding: 4px;
+    background-color: #383838;
+    border-bottom: solid 1px #959997;
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px;
+}
+
+.register-content__heading h2 {
+    margin: 0;
+    color: white;
+    font-size: 16px;
+    letter-spacing: 0.1em;
+    text-align: center;
+}
+
+.form-table {
+    width: 100%;
+}
+
+.form-table tr {
+    border-bottom: solid 1px #959997;
+}
+
+.form-table th {
+    width: 20%;
+    padding: 10px 20px;
+    border-right: solid 1px #959997;
+    font-weight: normal;
+    text-align: left;
+    background-color: #E0E5E3;
+}
+
+.form-table td {
+    padding: 10px 20px;
+}
+
+.form-table__input--text {
+    width: 100%;
+    padding: 1px 4px;
+    font-size: 14px;
+}
+
+.form__button {
+    margin: 20px 0;
+    text-align: center;
+}
+
+.form__button-submit {
+    width: 40%;
+    padding: 8px 0;
+    color: white;
+    background-color: #434343;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+}
+
+.form-table__error {
+    margin-top: 4px;
+    font-size: 14px;
+    font-weight: bold;
+    color: red;
+}

--- a/public/css/admin/create_admin_mail.css
+++ b/public/css/admin/create_admin_mail.css
@@ -1,15 +1,35 @@
-.register-wrapper {
+.admin-mail-wrapper {
     margin: 0 auto;
     max-width: 800px;
 }
 
-.register-content {
+.message {
+    margin-bottom: 10px;
+    padding: 10px 0;
+    text-align: center;
+}
+
+.is_sent--true {
+    color: #9CBAAB;
+    background-color: #BCE1CF;
+    border: solid 1px #9CBAAB;
+    border-radius: 6px;
+}
+
+.is_sent--false {
+    color: #FF475F;
+    background-color: #FEADB8;
+    border: solid 1px #FF475F;
+    border-radius: 6px;
+}
+
+.admin-mail-content {
     border: solid 1px #959997;
     border-radius: 8px;
     box-shadow: 2px 2px 3px #aaa;
 }
 
-.register-content__heading {
+.admin-mail-content__heading {
     padding: 4px;
     background-color: #383838;
     border-bottom: solid 1px #959997;
@@ -17,7 +37,7 @@
     border-top-right-radius: 6px;
 }
 
-.register-content__heading h2 {
+.admin-mail-content__heading h2 {
     margin: 0;
     color: white;
     font-size: 16px;

--- a/public/img/mail_white.svg
+++ b/public/img/mail_white.svg
@@ -1,0 +1,16 @@
+<!--?xml version="1.0" encoding="utf-8"?-->
+<!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg version="1.1" id="_x32_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="512px" height="512px" viewBox="0 0 512 512" style="width: 32px; height: 32px; opacity: 1;" xml:space="preserve">
+<style type="text/css">
+
+	.st0{fill:#4B4B4B;}
+
+</style>
+<g>
+	<path class="st0" d="M496.563,68.828H15.438C6.922,68.828,0,75.75,0,84.281v30.391l256,171.547l256-171.563V84.281
+		C512,75.75,505.078,68.828,496.563,68.828z" style="fill: rgb(255, 255, 255);"></path>
+	<path class="st0" d="M0,178.016v203.391c0,34.125,27.641,61.766,61.781,61.766h388.438c34.141,0,61.781-27.641,61.781-61.766V178
+		L256,349.563L0,178.016z" style="fill: rgb(255, 255, 255);"></path>
+</g>
+</svg>

--- a/resources/views/admin/app_admin.blade.php
+++ b/resources/views/admin/app_admin.blade.php
@@ -42,6 +42,10 @@
                     <img class="menu-icon" src="{{ asset('img/register.svg') }}" alt="home">
                     <a href="/admin/register_shop_owner">店舗代表者登録</a>
                 </li>
+                <li class="menu-list-item">
+                    <img class="menu-icon" src="{{ asset('img/mail_white.svg') }}" alt="home">
+                    <a href="/admin/admin_mail">お知らせメール</a>
+                </li>
                 @endif
                 @if (Auth::user()->role_id == 2)
                 <li class="menu-list-item">

--- a/resources/views/admin/create_admin_mail.blade.php
+++ b/resources/views/admin/create_admin_mail.blade.php
@@ -5,12 +5,17 @@
 @endsection
 
 @section('content')
-<div class="register-wrapper">
-    <div class="register-content">
-        <div class="register-content__heading">
+<div class="admin-mail-wrapper">
+    @if(session('is_sent') === true)
+    <div class="message is_sent--true">{{ session('message') }}</div>
+    @elseif(session('is_sent') === false)
+    <div class="message is_sent--false">{{ session('message') }}</div>
+    @endif
+    <div class="admin-mail-content">
+        <div class="admin-mail-content__heading">
             <h2>お知らせメール</h2>
         </div>
-        <form action="/admin/admin_mail" class="register-content__form" method="post">
+        <form action="/admin/admin_mail" class="admin-mail-content__form" method="post">
             @csrf
             <table class="form-table">
                 <tr>

--- a/resources/views/admin/create_admin_mail.blade.php
+++ b/resources/views/admin/create_admin_mail.blade.php
@@ -1,0 +1,46 @@
+@extends('admin.app_admin')
+
+@section('css')
+<link rel="stylesheet" href="{{ asset('css/admin/create_admin_mail.css') }}">
+@endsection
+
+@section('content')
+<div class="register-wrapper">
+    <div class="register-content">
+        <div class="register-content__heading">
+            <h2>お知らせメール</h2>
+        </div>
+        <form action="/admin/admin_mail" class="register-content__form" method="post">
+            @csrf
+            <table class="form-table">
+                <tr>
+                    <th>件名</th>
+                    <td>
+                        <input class="form-table__input--text" type="text" value="{{ old('name') }}" name="subject">
+                        <div class="form-table__error">
+                            @error('subject')
+                            ※{{ $message }}
+                            @enderror
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <th>本文</th>
+                    <td>
+                        <textarea class="form-table__input--text" rows="20" name="main_text">{{ old('detail') }}</textarea>
+                        <div class="form-table__error">
+                            @error('main_text')
+                            ※{{ $message }}
+                            @enderror
+                        </div>
+                    </td>
+                </tr>
+            </table>
+
+            <div class="form__button">
+                <button class="form__button-submit">送信</button>
+            </div>
+        </form>
+    </div>
+</div>
+@endsection

--- a/resources/views/emails/admin_mail.blade.php
+++ b/resources/views/emails/admin_mail.blade.php
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>お知らせメール</title>
+</head>
+
+<body>
+    <table width="100%" cellpadding="0" cellspacing="0" border="0">
+        <tr>
+            <td>
+                <p style="font-size: 18px; font-weight: bold;">{{ $name }}&nbsp;様</p>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <!-- <p>{{ $main_text }}</p> -->
+                <p>{!! nl2br(e( $main_text )) !!}</p>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <p>
+                ※本メールは送信専用です<br>
+                ------------------------------------------------------<br>
+                配信元&nbsp;:&nbsp;Rese
+                </p>
+            </td>
+        </tr>
+    </table>
+</body>
+
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,6 +29,8 @@ Route::group(['prefix' => 'admin'], function () {
     Route::group(['middleware' => ['verified', 'auth', 'administrator']], function () {
         Route::get('/register_shop_owner', [AdminController::class, 'createShopOwner']);
         Route::post('/register_shop_owner', [AdminController::class, 'storeShopOwner']);
+        Route::get('/admin_mail', [AdminController::class, 'createAdminMail']);
+        Route::post('/admin_mail', [AdminController::class, 'sendAdminMail']);
     });
 
     Route::group(['middleware' => ['verified', 'auth', 'shop_owner']], function () {


### PR DESCRIPTION
【実装内容】
- メール作成ページ create_admin_mail のview、cssを作成
- メールテンプレ admin_mail の作成
- メール作成ページ表示用ルーティングを追加（管理者権限ユーザーのみ表示可能）
- Mailableクラス AdminMail を新規作成
- AdminController に「上記ページ表示処理」「お知らせメール送信処理」を追加