### PR TITLE
管理画面のパスパラメータ {shop_index} を {shop_id} に変更し、影響箇所を全て修正

### DIFF
--- a/app/Http/Middleware/MyShopsMiddleware.php
+++ b/app/Http/Middleware/MyShopsMiddleware.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Support\Facades\Auth;
+use App\Models\Shop;
+
+class MyShopsMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        // 自身が作成した店舗以外の情報を表示しようとした場合はトップページへリダイレクト
+        // （※URL直打ちで他店舗の情報が見れてしまうのを防止する意図）
+        $id = Auth::id();
+        $owner_id = Shop::find($request->shop_id)->owner_id;
+        if ($id !== $owner_id) {
+            return redirect('/');
+        }
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 use App\Http\Middleware\AuthAdminMiddleware;
 use App\Http\Middleware\AuthAdministratorMiddleware;
 use App\Http\Middleware\AuthShopOwnerMiddleware;
+use App\Http\Middleware\MyShopsMiddleware;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -18,6 +19,7 @@ return Application::configure(basePath: dirname(__DIR__))
             'admin' => AuthAdminMiddleware::class,
             'administrator' => AuthAdministratorMiddleware::class,
             'shop_owner' => AuthShopOwnerMiddleware::class,
+            'my_shops' => MyShopsMiddleware::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {

--- a/resources/views/admin/app_admin.blade.php
+++ b/resources/views/admin/app_admin.blade.php
@@ -62,9 +62,9 @@
                             </span>
                         </summary>
                         <ul class="shop-list">
-                            @foreach($shops as $shop)
+                            @foreach($managing_shops as $shop)
                             <li>
-                                <a href="/admin/edit_shop_data/{{ $loop->index }}">
+                                <a href="/admin/edit_shop_data/{{ $shop->id }}">
                                 {{ $shop->name }}
                                 </a>
                             </li>
@@ -82,9 +82,9 @@
                             </span>
                         </summary>
                         <ul class="shop-list">
-                            @foreach($shops as $shop)
+                            @foreach($managing_shops as $shop)
                             <li>
-                                <a href="/admin/reservation_list/{{ $loop->index }}">
+                                <a href="/admin/reservation_list/{{ $shop->id }}">
                                 {{ $shop->name }}
                                 </a>
                             </li>

--- a/resources/views/admin/edit_shop_data.blade.php
+++ b/resources/views/admin/edit_shop_data.blade.php
@@ -10,13 +10,13 @@
         <div class="edit-content__heading">
             <h2>店舗情報</h2>
         </div>
-        <form action="/admin/edit_shop_data" class="edit-content__form" method="post" enctype="multipart/form-data">
+        <form action="/admin/edit_shop_data/{{ $shop->id }}" class="edit-content__form" method="post" enctype="multipart/form-data">
             @csrf
             <table class="form-table">
                 <tr>
                     <th>店名</th>
                     <td>
-                        <input class="form-table__input--text" type="text" value="{{ old('name', $shops[request()->shop_index]->name) }}" name="name">
+                        <input class="form-table__input--text" type="text" value="{{ old('name', $shop->name) }}" name="name">
                         <div class="form-table__error">
                             @error('name')
                             ※{{ $message }}
@@ -29,7 +29,7 @@
                     <td>
                         <select class="form-table__input--select" name="area">
                             @foreach(config('pref') as $key => $score)
-                            <option value="{{ $score }}" {{ $score == old('area', $shops[request()->shop_index]->area) ? 'selected' : '' }}>
+                            <option value="{{ $score }}" {{ $score == old('area', $shop->area) ? 'selected' : '' }}>
                             {{ $score }}
                             </option>
                             @endforeach
@@ -46,7 +46,7 @@
                     <td>
                         <select class="form-table__input--select" name="genre">
                             @foreach(config('genre') as $key => $score)
-                            <option value="{{ $score }}" {{ $score == old('genre', $shops[request()->shop_index]->genre) ? 'selected' : '' }}>
+                            <option value="{{ $score }}" {{ $score == old('genre', $shop->genre) ? 'selected' : '' }}>
                             {{ $score }}
                             </option>
                             @endforeach
@@ -61,7 +61,7 @@
                 <tr>
                     <th>紹介文</th>
                     <td>
-                        <textarea class="form-table__input--text" rows="5" name="detail">{{ old('detail', $shops[request()->shop_index]->detail) }}</textarea>
+                        <textarea class="form-table__input--text" rows="5" name="detail">{{ old('detail', $shop->detail) }}</textarea>
                         <div class="form-table__error">
                             @error('detail')
                             ※{{ $message }}
@@ -73,7 +73,7 @@
                     <th>サムネイル画像</th>
                     <td>
                         <div class="form-table__drop-area" id="drop-target">
-                            <img class="drop-area__preview" id="drop-area__preview" src="{{ asset('storage/' . $shops[request()->shop_index]->image) }}">
+                            <img class="drop-area__preview" id="drop-area__preview" src="{{ asset('storage/' . $shop->image) }}">
                         </div>
                         <input class="form-table__input--file" id="input-file" type="file" accept="image/*" name="images[]">
                         <div class="form-table__error">
@@ -84,9 +84,6 @@
                     </td>
                 </tr>
             </table>
-
-            <input type="hidden" value="{{ request()->shop_index }}" name="shop_index">
-            <input type="hidden" value="{{ $shops[request()->shop_index]->id }}" name="shop_id">
 
             <div class="form__button">
                 <button class="form__button-submit">更新する</button>

--- a/resources/views/admin/reservation_list.blade.php
+++ b/resources/views/admin/reservation_list.blade.php
@@ -7,7 +7,7 @@
 @section('content')
 <div class="container">
     <div class="heading-section">
-        <p class="heading__shop-name">{{ $shops[request()->shop_index]->name }}</p>
+        <p class="heading__shop-name">{{ $shop->name }}</p>
     </div>
     <div class="calendar-section">
         <div class="section__title">［予約カレンダー］</div>
@@ -15,13 +15,13 @@
             <div class="calendar-top">
                 <div class="calendar-top__year-month">{{ $this_year }}年{{ $this_month }}月</div>
                 <div class="calendar-top__button">
-                    <a class="button__this-month" href="/admin/reservation_list/{{ request()->shop_index }}">今月</a>
-                    <form action="/admin/reservation_list/{{ request()->shop_index }}" method="get">
+                    <a class="button__this-month" href="/admin/reservation_list/{{ request()->shop_id }}">今月</a>
+                    <form action="/admin/reservation_list/{{ request()->shop_id }}" method="get">
                         <input type="hidden" value="{{ $prev_year }}" name="year">
                         <input type="hidden" value="{{ $prev_month }}" name="month">
                         <button class="button__prev">&lt;</button>
                     </form>
-                    <form action="/admin/reservation_list/{{ request()->shop_index }}" method="get">
+                    <form action="/admin/reservation_list/{{ request()->shop_id }}" method="get">
                         <input type="hidden" value="{{ $next_year }}" name="year">
                         <input type="hidden" value="{{ $next_month }}" name="month">
                         <button class="button__next">&gt;</button>
@@ -59,7 +59,7 @@
                         ])>
                             <p class="table__days">{{ $day }}</p>
                             @if($people_num)
-                            <form action="/admin/reservation_list/{{ request()->shop_index }}" method="get">
+                            <form action="/admin/reservation_list/{{ request()->shop_id }}" method="get">
                                 <input type="hidden" value="{{ $this_year }}" name="year">
                                 <input type="hidden" value="{{ $this_month }}" name="month">
                                 <input type="hidden" value="{{ $year }}" name="time_schedule_year">

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,8 +36,12 @@ Route::group(['prefix' => 'admin'], function () {
     Route::group(['middleware' => ['verified', 'auth', 'shop_owner']], function () {
         Route::get('/register_shop_data', [AdminController::class, 'createShopData']);
         Route::post('/register_shop_data', [AdminController::class, 'storeShopData']);
-        Route::get('/edit_shop_data/{shop_index}', [AdminController::class, 'editShopData']);
-        Route::post('/edit_shop_data', [AdminController::class, 'updateShopData']);
-        Route::get('/reservation_list/{shop_index}', [AdminController::class, 'showReservationList']);
     });
+
+    Route::group(['middleware' => ['verified', 'auth', 'shop_owner', 'my_shops']], function () {
+        Route::get('/edit_shop_data/{shop_id}', [AdminController::class, 'editShopData']);
+        Route::post('/edit_shop_data/{shop_id}', [AdminController::class, 'updateShopData']);
+        Route::get('/reservation_list/{shop_id}', [AdminController::class, 'showReservationList']);
+    });
+
 });


### PR DESCRIPTION
【実装内容】
- 管理画面＞店舗情報の編集ページ、及び予約一覧ページの表示時に使用していたパスパラメータを【shop_index】から【shop_id】に変更
- MyShopsMiddleware を新規作成し、上記ページに関連するルーティングに設定
　※上記修正により、URL内の {shop_id} 部分を手入力して他ユーザーの店舗情報まで
　　表示出来てしまう状況となった為、これを防ぐミドルウェアとして追加