### PR TITLE
Fix/reserve

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -388,7 +388,11 @@ class AdminController extends Controller
     // 予約詳細の編集処理 ===========================================================
     public function updateReservation(Request $request) {
         $start_at = $request->reserve_time;
-        $finish_at = (new carbon($start_at))->addHour(2)->format('H:i');
+        $course_duration = 120;     // コース未設定の場合は一律120分に設定
+        if($request->reserve_course_id) {
+            $course_duration = Course::find($request->reserve_course_id)->duration_minutes;
+        }
+        $finish_at = (new carbon($start_at))->addMinutes($course_duration)->format('H:i');
 
         Reservation::find($request->reservation_id)
         ->update([

--- a/app/Http/Controllers/ShopController.php
+++ b/app/Http/Controllers/ShopController.php
@@ -319,7 +319,11 @@ class ShopController extends Controller
         try {
             DB::transaction(function () use ($request) {
                 $start_at = $request->reserve_time;
-                $finish_at = (new carbon($start_at))->addHour(2)->format('H:i');
+                $course_duration = 120;     // コース未設定の場合は一律120分に設定
+                if($request->reserve_course_id) {
+                    $course_duration = Course::find($request->reserve_course_id)->duration_minutes;
+                }
+                $finish_at = (new carbon($start_at))->addMinutes($course_duration)->format('H:i');
 
                 Reservation::find($request->reservation_id)
                     ->update([

--- a/app/Http/Controllers/ShopController.php
+++ b/app/Http/Controllers/ShopController.php
@@ -172,7 +172,10 @@ class ShopController extends Controller
             $user_id = Auth::user()->id;
             $shop_id = $request->shop_id;
             $start_at = $request->reserve_time;
-            $course_duration = Course::find($request->reserve_course_id)->duration_minutes;
+            $course_duration = 120;     // コース未設定の場合は一律120分に設定
+            if($request->reserve_course_id) {
+                $course_duration = Course::find($request->reserve_course_id)->duration_minutes;
+            }
             $finish_at = (new carbon($start_at))->addMinutes($course_duration)->format('H:i');
 
             // 予約情報の登録

--- a/app/Http/Controllers/ShopController.php
+++ b/app/Http/Controllers/ShopController.php
@@ -129,7 +129,7 @@ class ShopController extends Controller
         $shop = Shop::find($request->shop_id);
 
         // 予約時間セレクトボックス用の選択肢作成
-        $reservable_times = $this->getEqualIntervalTimes('16:00', '21:00', 30);
+        $reservable_times = $shop->getReservableTimes('16:00', '21:00', 30);
 
         // 予約可能最大人数
         $reserve_max_number = 10;
@@ -235,8 +235,7 @@ class ShopController extends Controller
         $reservations = Reservation::where('user_id', $user->id)->get();
         foreach ($reservations as $reservation) {
             $reservation->start_at = (new Carbon($reservation->start_at))->format("H:i");
-            $shop_id = $reservation->shop_id;
-            $reservation->shop_name = Shop::find($shop_id)->name;
+            $reservation->reservable_times = $reservation->shop->getReservableTimes('16:00', '21:00', 30);
         }
 
         // 取得した予約情報を「過去or未来」振り分け
@@ -259,8 +258,7 @@ class ShopController extends Controller
         }
 
         // 予約変更用パラメータの作成
-        $reservable_times = $this->getEqualIntervalTimes('16:00', '21:00', 30);
-        $reserve_max_number = 10;
+        $reserve_max_number = 10;   // 予約人数上限値
 
         return view('mypage',
             compact([
@@ -268,7 +266,6 @@ class ShopController extends Controller
                 'reservations',
                 'past_reservations',
                 'favorite_shops',
-                'reservable_times',
                 'reserve_max_number',
             ])
         );
@@ -371,19 +368,4 @@ class ShopController extends Controller
 
         return redirect('/mypage');
     }
-
-    // 等間隔の時間配列取得メソッド ========================================
-    private function getEqualIntervalTimes($start_time, $end_time, $span_minute) {
-        $span_minute = 30;
-
-        $time = new Carbon($start_time);
-        $end = new Carbon($end_time);
-        while ($time <= $end) {
-            $equal_interval_times[] = $time->format('H:i');
-            $time->addMinutes($span_minute);
-        }
-
-        return $equal_interval_times;
-    }
-
 }

--- a/resources/views/mypage.blade.php
+++ b/resources/views/mypage.blade.php
@@ -38,7 +38,7 @@
                     <table class="reserve-card__table">
                         <tr>
                             <th>Shop</th>
-                            <td>{{ $reservation->shop_name }}</td>
+                            <td>{{ $reservation->shop->name }}</td>
                         </tr>
                         <tr>
                             <th>Date</th>
@@ -116,7 +116,7 @@
                         <table class="reserve-card__table">
                             <tr>
                                 <th>Shop</th>
-                                <td>{{ $reservation->shop_name }}</td>
+                                <td>{{ $reservation->shop->name }}</td>
                             </tr>
                             <tr>
                                 <th>Date</th>
@@ -129,7 +129,7 @@
                                 <td>
                                     <select name="reserve_time">
                                         <option value="">-</option>
-                                        @foreach ($reservable_times as $reservable_time)
+                                        @foreach ( $reservation->reservable_times as $reservable_time)
                                         <option value="{{ $reservable_time }}" {{ old('reserve_time') ?? $reservation->start_at == $reservable_time ? 'selected' : '' }}>{{ $reservable_time }}</option>
                                         @endforeach
                                     </select>
@@ -213,7 +213,7 @@
                     <table class="reserve-card__table">
                         <tr>
                             <th>Shop</th>
-                            <td>{{ $reservation->shop_name }}</td>
+                            <td>{{ $reservation->shop->name }}</td>
                         </tr>
                         <tr>
                             <th>Date</th>
@@ -271,7 +271,7 @@
                         <table class="reserve-card__table">
                             <tr>
                                 <th>Shop</th>
-                                <td>{{ $reservation->shop_name }}</td>
+                                <td>{{ $reservation->shop->name }}</td>
                             </tr>
                             <tr>
                                 <th>Date</th>


### PR DESCRIPTION
【実装内容】
▼不具合修正
- コースを設定せずに予約した際に登録されない問題を修正
（コース未設定時はコース時間を120分固定設定する対応を追加）
- 予約済みコースの変更を行った際、これに伴う「予約終了時刻の変更」が行われていなかった問題を修正
（対応箇所：マイページでの予約変更、管理画面＞予約詳細ページでの予約編集）

▼ソースコード調整
- ShopController：getEqualIntervalTimes()を削除
（※ShopモデルのgetReservableTimesメソッドに置き換え）