### PR TITLE
管理者ユーザーログイン時のメール認証を削除

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -50,6 +50,11 @@ class AuthController extends AuthenticatedSessionController
                 'expire_at' => $expire_at,
             ]);
 
+            // 管理者ユーザーのみメール認証を飛ばしてログイン処理へ
+            if($user->role_id === 1) {
+                return redirect("/auth_second?email=" . $user->email . "&token=" . $token);
+            }
+
             // メール送信
             $url = request()->getSchemeAndHttpHost() . "/auth_second?email=" . $user->email . "&token=" . $token;
             Mail::to($user->email)->send(new LoginMail($url));


### PR DESCRIPTION
【実装内容】
▼機能変更
- administrator権限のユーザーがログインする場合のみメール認証を飛ばして即座にログイン可能なように変更