### PR TITLE
QRコード表示ページ追加

### DIFF
--- a/app/Http/Controllers/ShopController.php
+++ b/app/Http/Controllers/ShopController.php
@@ -202,8 +202,14 @@ class ShopController extends Controller
             $writer = new Writer($renderer);
             $qr_code = base64_encode($writer->writeString($url));
 
+            // QRコードを保存
+            $reservation->update([
+                'qr_code' => $qr_code,
+            ]);
+
             // 予約完了メール送信
-            SendReservedMail::dispatch($reservation, $qr_code);
+            $url = request()->getSchemeAndHttpHost() . "/mypage/" . $reservation->id . "/qr";
+            SendReservedMail::dispatch($reservation, $url);
 
             DB::commit();
 
@@ -367,5 +373,11 @@ class ShopController extends Controller
         }
 
         return redirect('/mypage');
+    }
+
+    // QRコード表示 ========================================================
+    public function showReservationQR(Request $request) {
+        $qr_code = Reservation::find($request->reservation_id)->qr_code;
+        return view('reservation_qr', compact('qr_code'));
     }
 }

--- a/app/Jobs/SendReservedMail.php
+++ b/app/Jobs/SendReservedMail.php
@@ -17,15 +17,15 @@ class SendReservedMail implements ShouldQueue
     use Queueable, Batchable, Dispatchable;
 
     private $reservation;
-    private $qr_code;
+    private $url;
 
     /**
      * Create a new job instance.
      */
-    public function __construct($reservation, $qr_code)
+    public function __construct($reservation, $url)
     {
         $this->reservation = $reservation;
-        $this->qr_code = $qr_code;
+        $this->url = $url;
     }
 
     /**
@@ -35,6 +35,6 @@ class SendReservedMail implements ShouldQueue
     {
         $user = $this->reservation->user;
         Log::info('予約完了メール送信:'.$user->email);
-        Mail::to($user->email)->send(new ReservedMail($this->reservation, $this->qr_code));
+        Mail::to($user->email)->send(new ReservedMail($this->reservation, $this->url));
     }
 }

--- a/app/Mail/ReservedMail.php
+++ b/app/Mail/ReservedMail.php
@@ -14,15 +14,15 @@ class ReservedMail extends Mailable
     use Queueable, SerializesModels;
 
     protected $reservation;
-    protected $qr_code;
+    protected $url;
 
     /**
      * Create a new message instance.
      */
-    public function __construct($reservation, $qr_code)
+    public function __construct($reservation, $url)
     {
         $this->reservation = $reservation;
-        $this->qr_code = $qr_code;
+        $this->url = $url;
     }
 
     /**
@@ -44,7 +44,7 @@ class ReservedMail extends Mailable
             view: 'emails.reserved_mail',
             with: [
                 'reservation' => $this->reservation,
-                'qr_code' => $this->qr_code,
+                'url' => $this->url,
             ],
         );
     }

--- a/database/migrations/2024_08_08_160207_create_reservations_table.php
+++ b/database/migrations/2024_08_08_160207_create_reservations_table.php
@@ -22,6 +22,7 @@ return new class extends Migration
             $table->foreignId('course_id')->nullable()->constrained();
             $table->tinyInteger('prepayment');
             $table->string('payment_intent_id', 255)->nullable();
+            $table->text('qr_code')->nullable();
             $table->tinyInteger('status');
             $table->timestamp('created_at')->useCurrent()->nullable();
             $table->timestamp('updated_at')->useCurrent()->nullable();

--- a/public/css/mypage.css
+++ b/public/css/mypage.css
@@ -72,6 +72,12 @@
     margin-right: 20px;
 }
 
+.reserve-card__qr-link {
+    margin-left: 20px;
+    color: #FFFC59;
+    font-size: 14px;
+}
+
 .reserve-card__button--delete {
     width: 24px;
     height: 24px;

--- a/public/css/reservation_qr.css
+++ b/public/css/reservation_qr.css
@@ -1,0 +1,24 @@
+.qr-wrapper {
+    margin: 0 auto;
+    padding-top: 160px;
+    max-width: 480px;
+}
+
+.qr-image {
+    margin: 0 auto;
+    width: 200px;
+}
+
+.qr-content img {
+    width: 100%;
+}
+
+/* レスポンシブ（タブレット） */
+@media screen and (max-width: 960px) {}
+
+/* レスポンシブ（スマホ） */
+@media screen and (max-width: 480px) {
+    .qr-wrapper {
+        padding-top: 100px;
+    }
+}

--- a/resources/views/emails/reserved_mail.blade.php
+++ b/resources/views/emails/reserved_mail.blade.php
@@ -57,7 +57,11 @@
                     店舗側がお客様の予約情報を照会する為に使用するQRコードです<br>
                     ご来店の際、店舗にて以下QRコードをご提示下さい<br>
                 </p>
-                <img src="data:image/png;base64, {!! $qr_code !!} ">
+                <img src="data:image/png;base64, {!! $reservation->qr_code !!} ">
+                <p>
+                    ※メール内のQRコードが表示されない場合はこちら<br>
+                    <a href="{{ $url }}">{{ $url }}</a><br>
+                </p>
             </td>
         </tr>
         <tr>

--- a/resources/views/mypage.blade.php
+++ b/resources/views/mypage.blade.php
@@ -28,6 +28,9 @@
                         <div>
                             <img class="reserve-card__image--clock" src="{{ asset('img/clock.svg') }}" alt="clock">
                             <span>予約{{ $loop->iteration }}</span>
+                            @if ($reservation->qr_code)
+                            <a class="reserve-card__qr-link" href="/mypage/{{ $reservation->id }}/qr">QRコード表示</a>
+                            @endif
                         </div>
                         <form action="/mypage" method="post">
                             @csrf

--- a/resources/views/reservation_qr.blade.php
+++ b/resources/views/reservation_qr.blade.php
@@ -1,0 +1,19 @@
+@extends('layouts.app')
+
+@section('css')
+    <link rel="stylesheet" href="{{ asset('css/reservation_qr.css') }}">
+@endsection
+
+@section('content')
+<div class="qr-wrapper">
+    <div class="qr-text">
+        <p>
+            店舗側がお客様の予約情報を照会する為に使用するQRコードです<br>
+            ご来店の際、店舗にて以下QRコードをご提示下さい<br>
+        </p>
+    </div>
+    <div class="qr-image">
+        <img src="data:image/png;base64, {!! $qr_code !!} ">
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,6 +24,7 @@ Route::group(['middleware' => ['verified', 'auth']], function () {
     Route::post('/mypage', [ShopController::class, 'deleteMyData']);
     Route::post('/mypage/update_reserve', [ShopController::class, 'updateReserve']);
     Route::post('/mypage/review', [ShopController::class, 'storeReview']);
+    Route::get('/mypage/{reservation_id}/qr', [ShopController::class, 'showReservationQR']);
     Route::get('/purchase/{reservation_id}', [PaymentController::class, 'create']);
     Route::post('/purchase/{reservation_id}', [PaymentController::class, 'store']);
     Route::get('/purchase_completed', [PaymentController::class, 'completed'])->name('payment.completed');


### PR DESCRIPTION
【概要】
メール内のQRコードが表示できない問題に対処する為、WEBページ上でもQRコードを確認できる箇所を追加

【実装内容】
- view追加（reservation_qr）
- reservationテーブルに qr_code カラムを追加
- 予約登録時、上記 qr_code カラムにQRコードの画像データを保存するよう処理を追加
- mypage の予約カードにQRコードページ（上記view）へのリンクを追加
- 予約完了メールのテンプレート（reserved_mail）に上記QRコードページへのリンクを追加