### PR TITLE
店舗一覧ページ、店舗詳細ページがログイン必須となっていた問題を修正

### DIFF
--- a/app/Http/Controllers/ShopController.php
+++ b/app/Http/Controllers/ShopController.php
@@ -62,12 +62,14 @@ class ShopController extends Controller
         }
 
         // お気に入り登録済み店舗の取得
-        $favorite_shops = Auth::user()->favoriteShops;
-        foreach ($shops as $shop) {
-            $shop->favorite_flag = 0;
-            foreach ($favorite_shops as $favorite_shop) {
-                if ($shop->id === $favorite_shop->id) {
-                    $shop->favorite_flag = 1;
+        if (Auth::user()) {
+            $favorite_shops = Auth::user()->favoriteShops;
+            foreach ($shops as $shop) {
+                $shop->favorite_flag = 0;
+                foreach ($favorite_shops as $favorite_shop) {
+                    if ($shop->id === $favorite_shop->id) {
+                        $shop->favorite_flag = 1;
+                    }
                 }
             }
         }

--- a/resources/views/shop_all.blade.php
+++ b/resources/views/shop_all.blade.php
@@ -53,12 +53,12 @@
                     @if($i <=$shop->rating)
                     <img src="{{ asset('img/star_on_gold.svg') }}" class="image--star" alt="star">
                     @elseif(($i - $shop->rating) < 0.5)
-                        <img src="{{ asset('img/star_on_half.png') }}" class="image--star" alt="star">
-                        @else
-                        <img src="{{ asset('img/star_on_gray.svg') }}" class="image--star" alt="star">
-                        @endif
-                        @endfor
-                        <span class="rating-value">{{ $shop->rating }}</span>
+                    <img src="{{ asset('img/star_on_half.png') }}" class="image--star" alt="star">
+                    @else
+                    <img src="{{ asset('img/star_on_gray.svg') }}" class="image--star" alt="star">
+                    @endif
+                @endfor
+                <span class="rating-value">{{ $shop->rating }}</span>
             </div>
             <div class="card-content__info">
                 <img src="{{ asset('img/speech_bubble_beige.svg') }}" alt="speech_bubble">
@@ -72,10 +72,10 @@
                     @csrf
                     <input type="hidden" name="shop_id" value="{{ $shop->id }}">
                     <input type="hidden" name="favorite_flag" value="{{ $shop->favorite_flag }}">
-                    @if ($shop->favorite_flag === 0)
-                    <input type="image" class="button-favorite" src="{{ asset('img/heart_gray.svg') }}" alt="favorite">
-                    @else
+                    @if ($shop->favorite_flag === 1)
                     <input type="image" class="button-favorite" src="{{ asset('img/heart_red.svg') }}" alt="favorite">
+                    @else
+                    <input type="image" class="button-favorite" src="{{ asset('img/heart_gray.svg') }}" alt="favorite">
                     @endif
                 </form>
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,17 +7,16 @@ use App\Http\Controllers\AuthController;
 use App\Http\Controllers\AdminController;
 use App\Http\Controllers\PaymentController;
 
-// Route::post('/register', [RegisterController::class, 'store']);
 Route::get('/auth_first', [AuthController::class, 'showMailAnnounce']);
 Route::post('/auth_first', [AuthController::class, 'authFirst']);
 Route::get('/auth_second', [AuthController::class, 'authSecond']);
 Route::get('/auth_error', [AuthController::class, 'showAuthError']);
+Route::get('/', [ShopController::class, 'index']);
+Route::get('/detail/{shop_id}', [ShopController::class, 'showShopDetail']);
 
 Route::group(['middleware' => ['verified', 'auth']], function () {
     Route::get('/thanks_register', [AuthController::class, 'showThanksRegister']);
-    Route::get('/', [ShopController::class, 'index']);
     Route::post('/', [ShopController::class, 'updateFavorites']);
-    Route::get('/detail/{shop_id}', [ShopController::class, 'showShopDetail']);
     Route::post('/detail/{shop_id}', [ShopController::class, 'reserve']);
     Route::get('/done', [ShopController::class, 'showThanksReserve']);
     Route::get('/mypage', [ShopController::class, 'showMypage']);
@@ -53,5 +52,4 @@ Route::group(['prefix' => 'admin'], function () {
         Route::post('/reservation_list/{shop_id}/detail/{reservation_id}/visit', [AdminController::class, 'visitReservation']);
         Route::post('/reservation_list/{shop_id}/detail/{reservation_id}/cancel', [AdminController::class, 'cancelReservation']);
     });
-
 });


### PR DESCRIPTION
【実装内容】
- 以下URLのルーティングをログイン不要へと変更
	- '/'
	- '/detail/{shop_id}'
- 店舗一覧ページ表示処理を修正
	- お気に入り店舗情報の取得処理をログインしている場合のみ行うよう変更
	（未ログインでも表示可能とした事に伴う修正対応）