### PR TITLE
管理画面＞決済済み予約の編集時のエラーを修正

### DIFF
--- a/resources/views/admin/reservation_edit.blade.php
+++ b/resources/views/admin/reservation_edit.blade.php
@@ -62,6 +62,7 @@
                         </div>
                         @else
                         {{ $reservation->number }} 名&emsp;※決済済み変更不可
+                        <input type="hidden" name="reserve_number" value="{{ $reservation->number }}">
                         @endif
                     </td>
                 </tr>
@@ -84,6 +85,7 @@
                         </div>
                         @else
                         {{ $reservation->course->name }}&emsp;※決済済み変更不可
+                        <input type="hidden" name="reserve_course_id" value="{{ $reservation->course_id }}">
                         @endif
                     </td>
                 </tr>
@@ -100,7 +102,9 @@
                             @endif
                         </select>
                         @elseif($reservation->prepayment == 2)決済完了
+                        <input type="hidden" name="reserve_prepayment" value="2">
                         @elseif($reservation->prepayment == 3)返金済み
+                        <input type="hidden" name="reserve_prepayment" value="3">
                         @endif
                     </td>
                 </tr>


### PR DESCRIPTION
【実装内容】
- 管理画面＞予約編集ページにおいて、決済完了している予約を編集した際にエラーが発生していた問題を修正
	- reservation->number、reserve_course_id、reserve_prepaymentの３つのパラメータを input type="hidden" で送信するように修正