### PR TITLE
店舗詳細ページのview,cssを微調整

### DIFF
--- a/public/css/shop_detail.css
+++ b/public/css/shop_detail.css
@@ -62,6 +62,7 @@
 
 .shop-info__description p {
     margin: 0;
+    white-space: pre-wrap;
 }
 
 .reserve-section {
@@ -351,6 +352,15 @@
 
     .confirm-table td {
         padding-left: 10px;
+    }
+
+    .review-section__body .body-top {
+        display: block;
+    }
+
+    .review-pagenation {
+        margin-top: 10px;
+        text-align: right;
     }
 
     .review-item {

--- a/resources/views/shop_detail.blade.php
+++ b/resources/views/shop_detail.blade.php
@@ -43,7 +43,7 @@
                 </div>
                 <div class="form__input">
                     <select name="reserve_time" class="form__input--select" id="form_time" onchange="setValue(this.value, 'confirm_time')">
-                        <option value="">予約時間を選択してください</option>
+                        <option value="">予約時間</option>
                         @foreach ($reservable_times as $reservable_time)
                         <option value="{{ $reservable_time }}" {{ old('reserve_time') == $reservable_time ? 'selected' : '' }}>{{ $reservable_time }}</option>
                         @endforeach
@@ -51,7 +51,7 @@
                 </div>
                 <div class="form__input">
                     <select name="reserve_number" class="form__input--select" id="form_number" onchange="setValue(this.value, 'confirm_number')">
-                        <option value="">予約人数を選択してください</option>
+                        <option value="">予約人数</option>
                         @for ($i = 1; $i <= $reserve_max_number; $i++)
                         <option value="{{$i}}" {{ old('reserve_number') == $i ? 'selected' : '' }}>{{$i}}人</option>
                         @endfor
@@ -59,7 +59,7 @@
                 </div>
                 <div class="form__input">
                     <select name="reserve_course_id" class="form__input--select" id="form_course" onchange="setCourseValue({{$shop->courses}}, this.value)">
-                        <option value="">コースを選択してください</option>
+                        <option value="">コース</option>
                         @foreach ($shop->courses as $course)
                         <option value="{{ $course->id }}" {{ old('reserve_course_id') == $course->id ? 'selected' : '' }}>{{ $course->name }}</option>
                         @endforeach
@@ -67,7 +67,7 @@
                 </div>
                 <div class="form__input">
                     <select name="reserve_prepayment" class="form__input--select" id="form_prepayment" onchange="setValue(this.options[this.selectedIndex].textContent, 'confirm_prepayment')">
-                        <option value="">お支払い方法を選択してください</option>
+                        <option value="">お支払い方法</option>
                         <option value=0 {{ old('reserve_prepayment') === "0" ? 'selected' : '' }}>店舗でのお支払い</option>
                         @if($shop->prepayment_enabled == 1)
                         <option value=1 {{ old('reserve_prepayment') === "1" ? 'selected' : '' }}>事前決済</option>
@@ -90,7 +90,7 @@
                         </tr>
                         <tr>
                             <th>Number</th>
-                            <td id="confirm_number">{{ old('reserve_number') ?? '-' }} 名</td>
+                            <td id="confirm_number">{{ old('reserve_number') ?? '-' }}</td>
                         </tr>
                         <tr>
                             <th>Course</th>


### PR DESCRIPTION
【実装内容】
- 予約カード：不要なテキストを（"名"の一文字）を削除
- 予約カード：「～を選択してください」の文言を削除（※コース設定が無い場合に不自然なため）
- 店舗情報欄：店舗説明文に改行が効いていなかった問題を修正
- 口コミ表示：SP表示、かつページネーションが増えた際に横幅が足りなくなる問題を修正