### PR TITLE
新規登録のメール認証が別ブラウザで行われないよう対処

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -36,9 +36,16 @@ class AuthController extends AuthenticatedSessionController
     public function authFirst(LoginRequest $request)
     {
         $user = User::where('email', $request->email)->first();
+
+        // 例外処理：メルアドに一致するユーザー無し
         if (empty($user)) {
             return redirect('/login')
                 ->with('message', Lang::get('message.ERR_USER_NOT_FOUND'));
+        }
+
+        // 例外処理：新規登録のメール認証が済んでいない
+        if (is_null($user->email_verified_at)) {
+            return view('auth.verify_email');
         }
 
         if (Hash::check($request->password, $user->password)) {
@@ -62,6 +69,7 @@ class AuthController extends AuthenticatedSessionController
             // メール送信済みページへリダイレクト
             return redirect('/auth_first')->with(['url' => $user->email]);
         } else {
+            // 例外処理：パスワードが一致しない
             return redirect('/login')
                 ->with('message', Lang::get('message.ERR_PASSWORD_MISMATCH'));
         }

--- a/public/css/auth/verify_email.css
+++ b/public/css/auth/verify_email.css
@@ -24,6 +24,10 @@
     font-size: 18px;
 }
 
+.verify-email-content__notification {
+    color: red;
+}
+
 .form__mail-button {
     margin-top: 40px;
     padding: 8px 16px;

--- a/resources/views/auth/verify_email.blade.php
+++ b/resources/views/auth/verify_email.blade.php
@@ -10,8 +10,13 @@
         <p class="verify-email-content__heading">会員登録はまだ完了していません。</p>
         <p class="verify-email-content__text">
             ご登録のメールアドレスへ認証用のメールを送信しました。<br>
-            ご確認いただき、メールに記載されたボタンをクリックして、<br>
+            ご確認いただき、メールに記載されたボタンをクリックして、
             会員登録を完了してください。
+        </p>
+        <p class="verify-email-content__notification">
+            ＜注意事項＞<br>
+            ボタン押下時、メールアプリや別のブラウザでページ表示される場合、認証処理が完了出来ません。
+            その場合はメール最下部に記載されているURLをコピーし、このブラウザのURL入力欄に直接貼り付けて認証を行って下さい。
         </p>
         <form class="verify-email-content__form" action="/email/verification-notification" method="post">
             @csrf


### PR DESCRIPTION
【概要】
ログイン時のメール認証において、認証リクエストが「メールアプリ」や「別ブラウザ」から送信される場合を考慮し、そちらでは認証出来ない旨をユーザーへ通知するように修正

【実装内容】
- 認証メール送信済みページに以下を追記
	- メールアプリや別ブラウザでは認証出来ないこと
	- その場合はメール記載のURLをコピペして、今使用中のブラウザで認証する必要があること
- ログイン時の2段階認証処理にて「新規登録時のメール認証が済んでいない場合の例外処理」を追加