### PR TITLE
動作確認用ダミーユーザーを調整

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -80,6 +80,11 @@ class AuthController extends AuthenticatedSessionController
                 return redirect("/auth_second?email=" . $user->email . "&token=" . $token);
             }
 
+            // 店舗代表者ダミーアカウントはメール認証を飛ばしてログイン処理へ
+            if ($user->email == 'dummy_shop_owner@example.com') {
+                return redirect("/auth_second?email=" . $user->email . "&token=" . $token);
+            }
+
             // メール送信
             $url = request()->getSchemeAndHttpHost() . "/auth_second?email=" . $user->email . "&token=" . $token;
             Mail::to($user->email)->send(new LoginMail($url));

--- a/database/seeders/UsersTableSeeder.php
+++ b/database/seeders/UsersTableSeeder.php
@@ -20,7 +20,7 @@ class UsersTableSeeder extends Seeder
             [
                 'role_id' => '1',
                 'name' => 'admin',
-                'email' => 'gmsp1000.3624@gmail.com',
+                'email' => 'admin@example.com',
                 'email_verified_at' => now(),
                 'password' => Hash::make('password'),
                 'remember_token' => Str::random(10),
@@ -28,7 +28,7 @@ class UsersTableSeeder extends Seeder
             [
                 'role_id' => '2',
                 'name' => 'dummy_shop_owner',
-                'email' => 'test@gmail.com',
+                'email' => 'dummy_shop_owner@example.com',
                 'email_verified_at' => now(),
                 'password' => Hash::make('password'),
                 'remember_token' => Str::random(10),


### PR DESCRIPTION
【実装内容】
- 動作確認用ダミーユーザーのメールアドレスを変更
	- 管理者：admin@example.com
	- 店舗代表者：dummy_shop_owner@example.com
- ログイン時のメール認証でダミーユーザーは除外する処理を追加