### PR TITLE
ページスクロール位置保存処理を修正

### DIFF
--- a/public/js/mypage.js
+++ b/public/js/mypage.js
@@ -45,3 +45,39 @@ window.onload = function () {
         readMore(content, button);
     });
 }
+
+//********************************************************************
+// ページのスクロール位置を保存 → 同ページが表示された際に復元
+//
+// ※ページネーション移動やお気に入り追加／削除などでスクロール位置が
+//   ページ最上部に戻ってしまうのを防ぐ意図
+//********************************************************************
+
+/**
+ * @type {number} scroll_position ページスクロール位置
+ * @type {string} STORAGE_KEY スクロール位置保存時のキー
+ */
+var scroll_position;
+const STORAGE_KEY = "mypage_scroll_position";
+
+console.log(STORAGE_KEY, scroll_position);
+
+/**
+ * スクロール位置保存メソッド
+ */
+function saveScrollPosition(){
+    scroll_position = window.scrollY;
+    sessionStorage.setItem(STORAGE_KEY, scroll_position);
+}
+
+/**
+ * ページがロードされた際に保存していたスクロール位置を復元
+ */
+window.addEventListener("load", function () {
+    scroll_position = sessionStorage.getItem(STORAGE_KEY);
+    if(scroll_position !== null){
+        scrollTo(0, scroll_position);
+    }
+    // ページスクロールされる度にスクロール位置を保存
+    window.addEventListener("scroll", saveScrollPosition, false);
+});

--- a/public/js/shop_all.js
+++ b/public/js/shop_all.js
@@ -1,0 +1,35 @@
+//********************************************************************
+// ページのスクロール位置を保存 → 同ページが表示された際に復元
+//
+// ※ページネーション移動やお気に入り追加／削除などでスクロール位置が
+//   ページ最上部に戻ってしまうのを防ぐ意図
+//********************************************************************
+
+/**
+ * @type {number} scroll_position ページスクロール位置
+ * @type {string} STORAGE_KEY スクロール位置保存時のキー
+ */
+var scroll_position;
+const STORAGE_KEY = "shop_all_scroll_position";
+
+console.log(STORAGE_KEY, scroll_position);
+
+/**
+ * スクロール位置保存メソッド
+ */
+function saveScrollPosition(){
+    scroll_position = window.scrollY;
+    sessionStorage.setItem(STORAGE_KEY, scroll_position);
+}
+
+/**
+ * ページがロードされた際に保存していたスクロール位置を復元
+ */
+window.addEventListener("load", function () {
+    scroll_position = sessionStorage.getItem(STORAGE_KEY);
+    if(scroll_position !== null){
+        scrollTo(0, scroll_position);
+    }
+    // ページスクロールされる度にスクロール位置を保存
+    window.addEventListener("scroll", saveScrollPosition, false);
+});

--- a/public/js/shop_detail.js
+++ b/public/js/shop_detail.js
@@ -36,3 +36,40 @@ function setCourseValue(courses, course_id) {
         }
    });
 }
+
+//********************************************************************
+// ページのスクロール位置を保存 → 同ページが表示された際に復元
+//
+// ※ページネーション移動やお気に入り追加／削除などでスクロール位置が
+//   ページ最上部に戻ってしまうのを防ぐ意図
+//********************************************************************
+
+/**
+ * @type {number} scroll_position ページスクロール位置
+ * @type {string} STORAGE_KEY スクロール位置保存時のキー
+ */
+var scroll_position;
+const SHOP_ID = document.getElementById('js_shop_id').value;
+const STORAGE_KEY = "shop_detail_" + SHOP_ID + "_scroll_position";
+
+console.log(STORAGE_KEY, scroll_position);
+
+/**
+ * スクロール位置保存メソッド
+ */
+function saveScrollPosition(){
+    scroll_position = window.scrollY;
+    sessionStorage.setItem(STORAGE_KEY, scroll_position);
+}
+
+/**
+ * ページがロードされた際に保存していたスクロール位置を復元
+ */
+window.addEventListener("load", function () {
+    scroll_position = sessionStorage.getItem(STORAGE_KEY);
+    if(scroll_position !== null){
+        scrollTo(0, scroll_position);
+    }
+    // ページスクロールされる度にスクロール位置を保存
+    window.addEventListener("scroll", saveScrollPosition, false);
+});

--- a/public/js/util.js
+++ b/public/js/util.js
@@ -12,37 +12,6 @@ function setValue(value, id) {
 }
 
 //********************************************************************
-// ページのスクロール位置を保存しておき、同ページが表示された際に復元する
-//********************************************************************
-
-/**
- * @type {number} scrollPosition ページスクロール位置
- * @type {string} STORAGE_KEY スクロール位置保存時のキー
- */
-var scrollPosition;
-const STORAGE_KEY = "scrollY";
-
-/**
- * スクロール位置保存メソッド
- */
-function saveScrollPosition(){
-    scrollPosition = window.scrollY;
-    localStorage.setItem(STORAGE_KEY, scrollPosition);
-}
-
-/**
- * ページがロードされた際に保存していたスクロール位置を復元
- */
-window.addEventListener("load", function(){
-    scrollPosition = localStorage.getItem(STORAGE_KEY);
-    if(scrollPosition !== null){
-        scrollTo(0, scrollPosition);
-    }
-    // ページスクロールされる度にスクロール位置を保存
-    window.addEventListener("scroll", saveScrollPosition, false);
-});
-
-//********************************************************************
 // 「もっと見る」ボタン押下時に隠れていた部分を展開する為のアクション登録
 //********************************************************************
 

--- a/resources/views/shop_all.blade.php
+++ b/resources/views/shop_all.blade.php
@@ -4,6 +4,10 @@
 <link rel="stylesheet" href="{{ asset('css/shop_all.css') }}">
 @endsection
 
+@section('script')
+<script src="{{ asset('js/shop_all.js') }}"></script>
+@endsection
+
 @section('content')
 <div class="search-section">
     <form action="" class="search-form">

--- a/resources/views/shop_detail.blade.php
+++ b/resources/views/shop_detail.blade.php
@@ -37,7 +37,7 @@
                 <div class="form__title">
                     <h3>予約</h3>
                 </div>
-                <input type="hidden" name="shop_id" value="{{ $shop->id }}">
+                <input type="hidden" name="shop_id" id="js_shop_id" value="{{ $shop->id }}">
                 <div class="form__input">
                     <input type="date" name="reserve_date" class="form__input--date" id="form_date" value="{{ old('reserve_date') }}" onchange="setValue(this.value, 'confirm_date')">
                 </div>


### PR DESCRIPTION
【概要】
保存したページスクロール位置が意図しない別ページにまで影響していた為、各ページ個別にスクロール位置を保存するように変更

【実装内容】
- util.jsからスクロール位置保存処理を削除
- 各ページごとのjsファイルに個別でスクロール位置保存処理を追加
	- shop_detail.js
	- mypage.js
	- shop_all.js（新規作成）
（※ `STORAGE_KEY` をそれぞれ別名称にしてページ個別の値として保存）
- shop_detail.jsに店舗IDを渡すため、shop_detail.blade.phpを調整