### PR TITLE
予約変更のバリデーション時に直前の入力値が表示されない問題を修正

### DIFF
--- a/resources/views/admin/reservation_edit.blade.php
+++ b/resources/views/admin/reservation_edit.blade.php
@@ -37,7 +37,7 @@
                         <select name="reserve_time" class="form__input--select">
                             <option value="">-</option>
                             @foreach ($reservable_times as $reservable_time)
-                            <option value="{{ $reservable_time }}" {{ old('reserve_time') ?? substr($reservation->start_at, 0, 5)  == $reservable_time ? 'selected' : '' }}>
+                            <option value="{{ $reservable_time }}" {{ old('reserve_time', substr($reservation->start_at, 0, 5)) == $reservable_time ? 'selected' : '' }}>
                                 {{ $reservable_time }}
                             </option>
                             @endforeach
@@ -73,7 +73,7 @@
                         <select name="reserve_course_id" class="form__input--select">
                             <option value="">-</option>
                             @foreach($shop->courses as $course)
-                            <option value="{{ $course->id }}" {{ old('reserve_course_id') ?? $reservation->course_id  == $course->id ? 'selected' : '' }}>
+                            <option value="{{ $course->id }}" {{ old('reserve_course_id', $reservation->course_id) == $course->id ? 'selected' : '' }}>
                                 {{ $course->name }}
                             </option>
                             @endforeach
@@ -96,7 +96,7 @@
                         <select name="reserve_prepayment" class="form__input--select">
                             <option value="0">なし</option>
                             @if($shop->prepayment_enabled == 1)
-                            <option value="1" {{ old('reserve_prepayment') ?? $reservation->prepayment  == 1 ? 'selected' : '' }}>
+                            <option value="1" {{ old('reserve_prepayment', $reservation->prepayment) == 1 ? 'selected' : '' }}>
                                 決済前
                             </option>
                             @endif
@@ -113,7 +113,7 @@
                     <td>
                         <select name="reserve_status" class="form__input--select">
                             <option value="0">来店前</option>
-                            <option value="1" {{ old('reserve_status') ?? $reservation->status  == 1 ? 'selected' : '' }}>来店済み</option>
+                            <option value="1" {{ old('reserve_status', $reservation->status) == 1 ? 'selected' : '' }}>来店済み</option>
                         </select>
                     </td>
                 </tr>

--- a/resources/views/auth/verify_email.blade.php
+++ b/resources/views/auth/verify_email.blade.php
@@ -16,7 +16,7 @@
         <p class="verify-email-content__notification">
             ＜注意事項＞<br>
             ボタン押下時、メールアプリや別のブラウザでページ表示される場合、認証処理が完了出来ません。
-            その場合はメール最下部に記載されているURLをコピーし、このブラウザのURL入力欄に直接貼り付けて認証を行って下さい。
+            その場合はメール最下部のURLをコピーし、このブラウザのURL入力欄に直接貼り付けて認証を行って下さい。
         </p>
         <form class="verify-email-content__form" action="/email/verification-notification" method="post">
             @csrf

--- a/resources/views/mypage.blade.php
+++ b/resources/views/mypage.blade.php
@@ -155,7 +155,7 @@
                                     <select name="reserve_time">
                                         <option value="">-</option>
                                         @foreach ( $reservation->reservable_times as $reservable_time)
-                                        <option value="{{ $reservable_time }}" {{ old('reserve_time') ?? $reservation->start_at == $reservable_time ? 'selected' : '' }}>{{ $reservable_time }}</option>
+                                        <option value="{{ $reservable_time }}" {{ old('reserve_time', $reservation->start_at) == $reservable_time ? 'selected' : '' }}>{{ $reservable_time }}</option>
                                         @endforeach
                                     </select>
                                 </td>
@@ -167,7 +167,7 @@
                                     <select name="reserve_number">
                                         <option value="">-</option>
                                         @for ($i = 1; $i <= $reserve_max_number; $i++)
-                                        <option value="{{$i}}" {{ old('reserve_number') ?? $reservation->number == $i ? 'selected' : '' }}>{{$i}} 名</option>
+                                        <option value="{{$i}}" {{ old('reserve_number', $reservation->number) == $i ? 'selected' : '' }}>{{$i}} 名</option>
                                         @endfor
                                     </select>
                                     @else
@@ -183,16 +183,11 @@
                                     <select name="reserve_course_id" class="form__input--select">
                                         <option value="">-</option>
                                         @foreach($reservation->shop->courses as $course)
-                                        <option value="{{ $course->id }}" {{ old('reserve_course_id') ?? $reservation->course_id  == $course->id ? 'selected' : '' }}>
+                                        <option value="{{ $course->id }}" {{ old('reserve_course_id', $reservation->course_id) == $course->id ? 'selected' : '' }}>
                                             {{ $course->name }}
                                         </option>
                                         @endforeach
                                     </select>
-                                    <div class="form-table__error">
-                                        @error('reserve_course_id')
-                                        ※{{ $message }}
-                                        @enderror
-                                    </div>
                                     @else
                                     <span>{{ $reservation->course->name }}</span>&emsp;<span>※変更不可</span>
                                     <input type="hidden" name="reserve_course_id" value="{{ $reservation->course_id }}">


### PR DESCRIPTION
【概要】
以下ページで予約変更する際にバリデーションに引っかかった場合、直前入力値が正しく表示されていなかった問題を修正

【実装内容】
- 以下bladeのold()ヘルパの引数を変更し、直前入力値が正しく表示されるように修正
	- mypage
	- reservation_edit