### PR TITLE
sp環境にて管理画面サイドメニュー下部が隠れる問題を修正

### DIFF
--- a/public/css/admin/app_admin.css
+++ b/public/css/admin/app_admin.css
@@ -160,5 +160,6 @@ details[open] .open-close-icon {
 @media screen and (max-width: 480px) {
     .side-menu {
         width: 100%;
+        padding-bottom: 80px;
     }
 }


### PR DESCRIPTION
【概要】
管理画面のサイドメニューが長くなった場合、sp環境で見るとメニュー下部が端末ブラウザのフッターメニューに重なってしまう問題を修正

【実装内容】
- app_admin.cssにてサイドメニュー下部のpaddingを変更